### PR TITLE
Use skip_empty_rows in call to read_fwf

### DIFF
--- a/R/read_data.R
+++ b/R/read_data.R
@@ -14,7 +14,8 @@ read_data = function(datafile,
     positions,
     col_types = col_types,
     locale = locale,
-    na = ""
+    na = "",
+    skip_empty_rows = FALSE
   )
 
   df = convert_factors(df, datamodel, numbered_enum)


### PR DESCRIPTION
In readr 1.4.0 read_fwf had a bug that caused `skip_empty_rows` not to
function properly when the rows had just whitespace. In readr 2.0.0 this
works as intended, which means if you would prefer the existing behavior
we would need to set this option to false in order for the tests to
pass.