### PR TITLE
Fixed minor confusing sentence in documentation parameter output_model

### DIFF
--- a/R/write_fwf_blaise.R
+++ b/R/write_fwf_blaise.R
@@ -16,7 +16,7 @@
 #' @param df dataframe to write
 #' @param output_data path and name to output datafile. Will add .asc if no extension
 #' @param output_model path and name to output datamodel. If NULL will use the
-#' same name as output_data with .bla extension unless and input_model is given.
+#' same name as output_data with .bla extension.
 #' @param decimal.mark decimal mark to use. Default is ".".
 #' @param digits how many significant digits are to be used for numeric and
 #' complex x. The default uses getOption("digits"). This is a suggestion:


### PR DESCRIPTION
Seems that if an output_model is given that name is used. If output_model is NULL(or not given) the same name as output_data is used with the .bla extension 